### PR TITLE
Update Readme.md for installation of Chia-Plotter under CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ scl enable devtoolset-7 bash
 ./build/chia_plot --help
 ```
 ---
+
+### CentOS 8
+How to install chia-Plotter on CentOS 8
+
 ### Clear Linux
 Read [install file](doc/install_clearlinux.md)
 


### PR DESCRIPTION
Hallo Max,

as mentioned in the Discord server, it currently isn't possible to install the "chia-plotter" under CentOS 8.

Therefore an update for CentOS 8 would be necessary. My try to install "chia-plotter" under CentOS 8 failed. First, some dependencies are not available for CentOS 8 and some are probably not required anymore. However, I had to install "Cmake" and I used this HowTo-Article: `https://www.osradar.com/how-to-install-cmake-on-centos-8/ `
Nevertheless, the execution of `./make_devel.sh `failed with the following error:

`"/usr/bin/ar: /usr/lib64/libgmp.so File Format not recognized"`

Last but not least, I would like to thank you for you effort creating this piece of software. 

Best regards 4thHorseman